### PR TITLE
Fixes #4 - flash of the button in top left corner

### DIFF
--- a/SpreadButton/ZYSpreadButton/Classes/objc/ZYSpreadButton.m
+++ b/SpreadButton/ZYSpreadButton/Classes/objc/ZYSpreadButton.m
@@ -301,12 +301,10 @@
 
 - (void)closeSubButton:(ZYSpreadSubButton *)exclusiveBtn {
     for (ZYSpreadSubButton *btn in _subButtons) {
-        if (exclusiveBtn != nil) {
-            if (btn != exclusiveBtn) {
-                [btn removeFromSuperview];
-            }
-            continue;
+        if (btn != exclusiveBtn) {
+            [btn removeFromSuperview];
         }
+        continue;
         
         UIBezierPath *animationPath = [self movingPathWithStartPoint:btn.layer.position keyPointCount:1 keyPoints:_powerButton.layer.position, nil];
         CAKeyframeAnimation *positionAnimation = [CAKeyframeAnimation animationWithKeyPath:@"position"];

--- a/SpreadButton/ZYSpreadButton/Classes/swift/SpreadButton.swift
+++ b/SpreadButton/ZYSpreadButton/Classes/swift/SpreadButton.swift
@@ -400,12 +400,10 @@ class SpreadButton: UIView, CAAnimationDelegate {
     
     func closeSubButton(_ exclusiveBtn: SpreadSubButton?) {
         for btn in subButtons! {
-            if exclusiveBtn != nil {
-                if btn != exclusiveBtn {
-                    btn.removeFromSuperview()
-                }
-                continue
+            if btn != exclusiveBtn {
+                btn.removeFromSuperview()
             }
+            continue
             
             let animationPath = movingPath(btn.layer.position, keyPoints: powerButton.layer.position)
             let positionAnimation = CAKeyframeAnimation(keyPath: "position")


### PR DESCRIPTION
The sub-buttons flashes if user clicks on dimmed background or close button. The reason is that exclusive button is nil (no button was tapped) and the sub-buttons are not removed from parent.